### PR TITLE
Update pzip_storage.py

### DIFF
--- a/pzip_storage.py
+++ b/pzip_storage.py
@@ -12,9 +12,9 @@ __version__ = "0.9.9"
 __version_info__ = tuple(int(num) for num in __version__.split("."))
 
 
-needs_rotation = django.dispatch.Signal(providing_args=["storage", "name", "key"])
-needs_encryption = django.dispatch.Signal(providing_args=["storage", "name"])
-bad_keys = django.dispatch.Signal(providing_args=["storage", "name"])
+needs_rotation = django.dispatch.Signal()
+needs_encryption = django.dispatch.Signal()
+bad_keys = django.dispatch.Signal()
 
 
 class IntermediateFile:


### PR DESCRIPTION
While updating a site to Django 4.1, I had to make a minor change. The providing_args keyword argument was deprecated in Django 3.1 and has been removed.